### PR TITLE
Fix: Add group write perms to /etc/redis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ COPY setupMasterSlave.sh /usr/bin/setupMasterSlave.sh
 
 COPY healthcheck.sh /usr/bin/healthcheck.sh
 
-RUN chmod -R g+rwX /etc/redis
+RUN mkdir -p /opt/redis/ && \
+    chmod -R g+rwX /etc/redis /opt/redis
 
 VOLUME ["/data"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ COPY setupMasterSlave.sh /usr/bin/setupMasterSlave.sh
 
 COPY healthcheck.sh /usr/bin/healthcheck.sh
 
+RUN chmod -R g+rwX /etc/redis
+
 VOLUME ["/data"]
 
 WORKDIR /data


### PR DESCRIPTION
By default OpenShift runs as a non-root user but the GID is always 0.  To allow `entrypoint.sh` to configure redis at container start, we need to change the permissions so that GID 0 users can modify `/etc/redis` and it's contents.