### PR TITLE
fix/external-config-persistence-settings-get-overwritten

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,13 +80,13 @@ start_redis() {
 }
 
 main_function() {
-    if [[ -f "${EXTERNAL_CONFIG_FILE}" ]]; then
-        external_config
-    fi
     common_operation
     set_redis_password
     redis_mode_setup
     persistence_setup
+    if [[ -f "${EXTERNAL_CONFIG_FILE}" ]]; then
+        external_config
+    fi
     start_redis
 }
 


### PR DESCRIPTION
Save and appendonly settings from external config are getting overwritten by entrypoint.sh.

This PR fixes it by only changing the order of the functions.