### PR TITLE
fix the data directory permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,8 @@ VOLUME ["/data"]
 
 WORKDIR /data
 
+RUN chown redis:redis /data
+
 EXPOSE 6379
 
 USER 1000


### PR DESCRIPTION
the data directory in the redis image is owned by root:root which prohibits the redis process of writing to it so we change that to the correct owner and group