### PR TITLE
[redis] Update base and exporter version

### DIFF
--- a/Dockerfile.exporter
+++ b/Dockerfile.exporter
@@ -2,7 +2,7 @@ FROM alpine:3.15 as builder
 
 ARG EXPORTER_URL="https://github.com/oliver006/redis_exporter/releases/download"
 
-ARG REDIS_EXPORTER_VERSION="1.44.0"
+ARG REDIS_EXPORTER_VERSION="1.48.0"
 
 RUN  apk add --no-cache curl ca-certificates && \
       curl -fL -Lo /tmp/redis_exporter-v${REDIS_EXPORTER_VERSION}.linux-amd64.tar.gz \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-REDIS_VERSION ?= v7.0.5
-EXPORTER_VERSION ?= v1.44.0
+REDIS_VERSION ?= v7.0.9
+EXPORTER_VERSION ?= v1.48.0
 
 IMG ?= quay.io/opstree/redis:$(REDIS_VERSION)
 EXPORTER_IMG ?= opstree/redis-exporter:$(EXPORTER_VERSION)


### PR DESCRIPTION
To get latest features and security updates.

- Redis: v7.0.9
- Redis-Exporter: v1.48.0