### PR TITLE
Fix: Make sure /etc/redis is writable by the root group.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,9 @@ COPY setupMasterSlave.sh /usr/bin/setupMasterSlave.sh
 
 COPY healthcheck.sh /usr/bin/healthcheck.sh
 
-RUN chown -R redis:redis /etc/redis
+# Make configuration writable for root for OpenShift compatibility
+RUN chown -R 1000:0 /etc/redis && \
+    chmod -R g+rw /etc/redis
 
 VOLUME ["/data"]
 


### PR DESCRIPTION
This makes `/etc/redis` writable by the root group so the container can be initialised on OpenShift. I don't think this causes any issues on other k8s platforms.

This is the same change as #4, but this got reverted later on in #14. I'm not sure why.

I've also had to make `/data` writable. See also https://github.com/OT-CONTAINER-KIT/redis/pull/22

Fixes #24 