### PR TITLE
fix insecure password passing during redis-cluster startup

### DIFF
--- a/setupMasterSlave.sh
+++ b/setupMasterSlave.sh
@@ -6,14 +6,16 @@ redis_server_mode() {
         if [[ -z "${REDIS_PASSWORD}" ]]; then
              redis-cli --cluster create "${MASTER_LIST}" --cluster-yes
         else
-            redis-cli --cluster create "${MASTER_LIST}" --cluster-yes -a "${REDIS_PASSWORD}"
+            export REDISCLI_AUTH="${REDIS_PASSWORD}"
+            redis-cli --cluster create "${MASTER_LIST}" --cluster-yes
         fi
     elif [[ "${SERVER_MODE}" == "slave" ]]; then
         echo "Redis server mode is slave"
         if [[ -z "${REDIS_PASSWORD}" ]]; then
             redis-cli --cluster add-node "${SLAVE_IP}" "${MASTER_IP}" --cluster-slave
         else
-            redis-cli --cluster add-node "${SLAVE_IP}" "${MASTER_IP}" --cluster-slave -a "${REDIS_PASSWORD}"
+            export REDISCLI_AUTH="${REDIS_PASSWORD}"
+            redis-cli --cluster add-node "${SLAVE_IP}" "${MASTER_IP}" --cluster-slave
         fi
     else
         echo "Redis server mode is standalone"


### PR DESCRIPTION
During redis-cluster pod startup, while the leader and follower pods are self-registering, they provide passwords in plaintext, which is visible in observability/security tools watching the kubernetes control plane. This PR implements the fix described [here](https://redis.io/docs/ui/cli/#host-port-password-and-database): "NOTE: For security reasons, provide the password to redis-cli automatically via the REDISCLI_AUTH environment variable."