### PR TITLE
Add write by root permission to support Openshift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,11 @@ COPY setupMasterSlave.sh /usr/bin/setupMasterSlave.sh
 
 COPY healthcheck.sh /usr/bin/healthcheck.sh
 
-RUN chown -R redis:redis /etc/redis
+RUN chown -R 1000:0 /etc/redis && \
+    chmod -R g+rw /etc/redis && \
+    mkdir /data && \
+    chown -R 1000:0 /data && \
+    chmod -R g+rw /data
 
 VOLUME ["/data"]
 


### PR DESCRIPTION
### This PR addresses next issues:
- https://github.com/OT-CONTAINER-KIT/redis/pull/25 https://github.com/OT-CONTAINER-KIT/redis/issues/24 "Fix: Make sure /etc/redis is writable by the root group"
- https://github.com/OT-CONTAINER-KIT/redis/pull/22 "fix the data directory permissions"

### How I tested it
- build image with name redis7
```bash
$ docker build . -t redis7
```

- run 2 containers - without and with 'runAsUser' option:
    ```
    $ docker run --rm --name test-uid -d redis7
    $ docker run --rm --name test-uid-1001 --user 1001 -d redis7```

    # make sure that config file and data directory is writeable
    $ docker exec test-uid bash -c "echo 1 > /etc/redis/redis.conf"
    $ echo $?
    0
    $ docker exec test-uid bash -c "echo 1 > /data/1"
    $ echo $?
    0

    # make sure that config file and data directory is writeable for '1001 user'
    $ docker exec test-uid-1001 bash -c "echo 1 > /data/1"
    $ echo $?
    0
    $ docker exec test-uid-1001 bash -c "echo 1 > /etc/redis/redis.conf"
    $ echo $?
    0
    ```
    no errors

- Let's check intended users:
    ```bash
    $ docker exec test-uid bash -c "echo $UID"
    1000

    $ docker exec test-uid-1001 bash -c "echo $UID"
    1000
    ```

    ```
    $ docker exec test-uid bash -c "whoami"
    redis

    $ docker exec test-uid-1001 bash -c "whoami"
    whoami: unknown uid 1001
    ```
    UIDs as expected

