### PR TITLE
[Feature] : Cluster announce to nodeip 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -106,9 +106,15 @@ external_config() {
 start_redis() {
     if [[ "${SETUP_MODE}" == "cluster" ]]; then
         echo "Starting redis service in cluster mode....."
+        if [[ "${NODEPORT}" == "true" ]]; then
+            CLUSTER_ANNOUNCE_IP="node-ip-$(hostname)"
+        else
+            CLUSTER_ANNOUNCE_IP="${POD_IP}"
+        fi
+
         if [[ "${REDIS_MAJOR_VERSION}" != "v7" ]]; then
           redis-server /etc/redis/redis.conf \
-          --cluster-announce-ip "${POD_IP}" \
+          --cluster-announce-ip "${CLUSTER_ANNOUNCE_IP}" \
           --cluster-announce-hostname "${POD_HOSTNAME}"
         else
           redis-server /etc/redis/redis.conf


### PR DESCRIPTION
This PR introduces an approach to announce redis cluster on some stable node-ip.

You need to pass env variable `NODEPORT=true`
to use the node-ip on redis instead of default pod-ip is assigned. 


You can set the node-ip variable on pods according to 
`node-ip-<your-pod-name>`=10.12.12.34

Since the pod names are predictable. 
