### PR TITLE
Fix redis-sentinel entrypoint & directory permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,10 @@ RUN chown -R 1000:0 /etc/redis && \
     chmod -R g+rw /etc/redis && \
     mkdir /data && \
     chown -R 1000:0 /data && \
-    chmod -R g+rw /data
+    chmod -R g+rw /data && \
+    mkdir /node-conf && \
+    chown -R 1000:0 /node-conf && \
+    chmod -R g+rw /node-conf
 
 VOLUME ["/data"]
 

--- a/Dockerfile.sentinel
+++ b/Dockerfile.sentinel
@@ -36,7 +36,11 @@ COPY entrypoint-sentinel.sh /usr/bin/entrypoint-sentinel.sh
 
 COPY healthcheck-Sentinel.sh /usr/bin/healthcheck.sh
 
-RUN chown -R redis:redis /etc/redis
+RUN chown -R 1000:0 /etc/redis && \
+    chmod -R g+rw /etc/redis && \
+    mkdir /sentinel-data && \
+    chown -R 1000:0 /sentinel-data && \
+    chmod -R g+rw /sentinel-data
 
 VOLUME ["/sentinel-data"]
 

--- a/entrypoint-sentinel.sh
+++ b/entrypoint-sentinel.sh
@@ -89,3 +89,5 @@ main_function() {
   fi
   start_sentinel
 }
+
+main_function


### PR DESCRIPTION
Using Redis Operator in OKD we have problems with the redis and redis-sentinel images.

- v7.0.12 redis-sentinel doesn't start because the main_function call is missing from the image
- in OKD when the containers run with default user constraints (generated uid over 1000), the directory permissions are not satisfying