### PR TITLE
Support start redis received signal

### DIFF
--- a/entrypoint-sentinel.sh
+++ b/entrypoint-sentinel.sh
@@ -71,11 +71,8 @@ acl_setup(){
 }
 
 start_sentinel() {
-
   echo "Starting  sentinel service ....."
-    redis-sentinel /etc/redis/sentinel.conf
-  
-
+  exec redis-sentinel /etc/redis/sentinel.conf
 }
 
 main_function() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -114,7 +114,7 @@ start_redis() {
         fi
         
         if [[ "${REDIS_MAJOR_VERSION}" != "v7" ]]; then
-          redis-server /etc/redis/redis.conf \
+          exec redis-server /etc/redis/redis.conf \
           --cluster-announce-ip "${CLUSTER_ANNOUNCE_IP}" \
           --cluster-announce-hostname "${POD_HOSTNAME}"
         else
@@ -123,12 +123,12 @@ start_redis() {
             echo cluster-announce-hostname "${POD_HOSTNAME}"
           } >> /etc/redis/redis.conf
 
-          redis-server /etc/redis/redis.conf
+          exec redis-server /etc/redis/redis.conf
         fi
 
     else
         echo "Starting redis service in standalone mode....."
-        redis-server /etc/redis/redis.conf
+        exec redis-server /etc/redis/redis.conf
     fi
 }
 


### PR DESCRIPTION
```
➜  ~ docker ps
CONTAINER ID   IMAGE                           COMMAND                   CREATED         STATUS         PORTS      NAMES
8d83f21e8e1d   quay.io/opstree/redis:v7.0.12   "/usr/bin/entrypoint…"   8 seconds ago   Up 7 seconds   6379/tcp   cranky_clarke
➜  ~ docker kill -s SIGTERM cranky_clarke
cranky_clarke
```
redis log:
```
2023-10-07 22:41:46 Redis is running without password which is not recommended
2023-10-07 22:41:46 Setting up redis in standalone mode
2023-10-07 22:41:46 Running without persistence mode
2023-10-07 22:41:46 Running without TLS mode
2023-10-07 22:41:46 ACL_MODE is not true, skipping ACL file modification
2023-10-07 22:41:46 Starting redis service in standalone mode.....
2023-10-07 22:41:46 1:C 07 Oct 2023 14:41:46.166 * oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
2023-10-07 22:41:46 1:C 07 Oct 2023 14:41:46.166 * Redis version=7.2.1, bits=64, commit=00000000, modified=0, pid=1, just started
2023-10-07 22:41:46 1:C 07 Oct 2023 14:41:46.166 * Configuration loaded
2023-10-07 22:41:46 1:M 07 Oct 2023 14:41:46.166 * monotonic clock: POSIX clock_gettime
2023-10-07 22:41:46 1:M 07 Oct 2023 14:41:46.167 # Failed to write PID file: Permission denied
2023-10-07 22:41:46 1:M 07 Oct 2023 14:41:46.167 * Running mode=standalone, port=6379.
2023-10-07 22:41:46 1:M 07 Oct 2023 14:41:46.167 * Server initialized
2023-10-07 22:41:46 1:M 07 Oct 2023 14:41:46.167 * Ready to accept connections tcp
2023-10-07 22:42:09 1:signal-handler (1696689729) Received SIGTERM scheduling shutdown...
2023-10-07 22:42:09 1:M 07 Oct 2023 14:42:09.419 * User requested shutdown...
2023-10-07 22:42:09 1:M 07 Oct 2023 14:42:09.419 * Saving the final RDB snapshot before exiting.
2023-10-07 22:42:09 1:M 07 Oct 2023 14:42:09.424 * DB saved on disk
2023-10-07 22:42:09 1:M 07 Oct 2023 14:42:09.424 * Removing the pid file.
2023-10-07 22:42:09 1:M 07 Oct 2023 14:42:09.424 # Redis is now ready to exit, bye bye...
```