### PR TITLE
Support custom redis port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ LABEL maintainer="Opstree Solutions"
 
 ARG TARGETARCH
 
+ENV REDIS_PORT=6379
+
 LABEL version=1.0 \
       arch=$TARGETARCH \
       description="A production grade performance tuned redis docker image created by Opstree Solutions"
@@ -62,7 +64,7 @@ VOLUME ["/node-conf"]
 
 WORKDIR /data
 
-EXPOSE 6379
+EXPOSE ${REDIS_PORT}
 
 USER 1000
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -99,6 +99,12 @@ persistence_setup() {
     fi
 }
 
+port_setup() {
+        {
+            echo port "${REDIS_PORT}"
+        } >> /etc/redis/redis.conf
+}
+
 external_config() {
     echo "include ${EXTERNAL_CONFIG_FILE}" >> /etc/redis/redis.conf
 }
@@ -139,6 +145,7 @@ main_function() {
     persistence_setup
     tls_setup
     acl_setup
+    port_setup
     if [[ -f "${EXTERNAL_CONFIG_FILE}" ]]; then
         external_config
     fi

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -5,9 +5,9 @@ check_redis_health() {
         export REDISCLI_AUTH="${REDIS_PASSWORD}"
     fi
     if [[ "${TLS_MODE}" == "true" ]]; then
-        redis-cli --tls --cert "${REDIS_TLS_CERT}" --key "${REDIS_TLS_CERT_KEY}" --cacert "${REDIS_TLS_CA_KEY}" -h "$(hostname)" ping
+        redis-cli --tls --cert "${REDIS_TLS_CERT}" --key "${REDIS_TLS_CERT_KEY}" --cacert "${REDIS_TLS_CA_KEY}" -h "$(hostname)" -p "${REDIS_PORT}" ping
     else
-        redis-cli -h "$(hostname)" ping
+        redis-cli -h "$(hostname)" -p "${REDIS_PORT}" ping
     fi
 }
 


### PR DESCRIPTION
1. Run without port env:
<img width="1195" alt="截屏2023-12-08 14 04 20" src="https://github.com/OT-CONTAINER-KIT/redis/assets/32033618/f987183b-87e6-4fb0-a42d-c4a1027c6a23">

2. Run with port env:
<img width="1194" alt="截屏2023-12-08 14 03 52" src="https://github.com/OT-CONTAINER-KIT/redis/assets/32033618/83bd3cfb-c4e4-41ec-a485-292f0c0ea241">
