### PR TITLE
fix announce-port && announce-bus-port env

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -105,6 +105,10 @@ port_setup() {
         } >> /etc/redis/redis.conf
 
         if [[ "${NODEPORT}" == "true" ]]; then
+            CLUSTER_ANNOUNCE_PORT_VAR="announce_port_$(hostname | tr '-' '_')"
+            CLUSTER_ANNOUNCE_BUS_PORT_VAR="announce_bus_port_$(hostname | tr '-' '_')"
+            CLUSTER_ANNOUNCE_PORT="${!CLUSTER_ANNOUNCE_PORT_VAR}"
+            CLUSTER_ANNOUNCE_BUS_PORT="${!CLUSTER_ANNOUNCE_BUS_PORT_VAR}"
             {
                 echo cluster-announce-port "${CLUSTER_ANNOUNCE_PORT}"
                 echo cluster-announce-bus-port "${CLUSTER_ANNOUNCE_BUS_PORT}"


### PR DESCRIPTION
Becouse all (leader/follower) pod generate from one pod template. We should pass all port to container env, like:
<img width="634" alt="截屏2023-12-26 14 26 26" src="https://github.com/OT-CONTAINER-KIT/redis/assets/32033618/8b6e9e24-d210-4217-a237-c3724f30f1ad">
