### PR TITLE
fix: tls-port can not use 6379 which be used by redis port

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,8 +52,6 @@ redis_mode_setup() {
 tls_setup() {
     if [[ "${TLS_MODE}" == "true" ]]; then
         {
-            echo port 0
-            echo tls-port 6379
             echo tls-cert-file "${REDIS_TLS_CERT}"
             echo tls-key-file "${REDIS_TLS_CERT_KEY}"
             echo tls-ca-cert-file "${REDIS_TLS_CA_KEY}"
@@ -100,9 +98,16 @@ persistence_setup() {
 }
 
 port_setup() {
-        {
-            echo port "${REDIS_PORT}"
-        } >> /etc/redis/redis.conf
+        if [[ "${TLS_MODE}" == "true" ]]; then
+            {
+                echo port 0
+                echo tls-port "${REDIS_PORT}"
+            } >> /etc/redis/redis.conf
+        else
+            {
+                echo port "${REDIS_PORT}"
+            } >> /etc/redis/redis.conf
+        fi
 
         if [[ "${NODEPORT}" == "true" ]]; then
             CLUSTER_ANNOUNCE_PORT_VAR="announce_port_$(hostname | tr '-' '_')"


### PR DESCRIPTION
When start redis use `TLS_MODE=true`, the redis exited with error:
<img width="1180" alt="截屏2024-02-01 11 20 10" src="https://github.com/OT-CONTAINER-KIT/redis/assets/32033618/eaf41cd7-f636-469c-88f1-782b60a1535a">

Because `port 0` by overwrited by `port "${REDIS_PORT}"` in `port_setup()`.