### PR TITLE
Fix replication for TLS leader/follower configurations

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,11 +57,11 @@ tls_setup() {
             echo tls-ca-cert-file "${REDIS_TLS_CA_KEY}"
             # echo tls-prefer-server-ciphers yes
             echo tls-auth-clients optional
+            echo tls-replication yes
         } >> /etc/redis/redis.conf
 
         if [[ "${SETUP_MODE}" == "cluster" ]]; then
             {
-                echo tls-replication yes
                 echo tls-cluster yes
                 echo cluster-preferred-endpoint-type hostname
             } >> /etc/redis/redis.conf


### PR DESCRIPTION
When a redis replication setup is done using TLS, the followers are unable to communicate with the leader as they won't use TLS without setting `tls-replication yes`