### PR TITLE
Add manual release workflow for Redis components

### DIFF
--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -1,0 +1,65 @@
+name: Manual Docker Image Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      component:
+        description: 'Select component to release'
+        required: true
+        type: choice
+        options:
+          - redis
+          - sentinel
+          - exporter
+      version:
+        description: 'Input version to release (e.g. v1.0.0)'
+        required: true
+        type: string
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Login to Quay
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      
+      - name: Set build configuration
+        id: config
+        run: |
+          if [ "${{ github.event.inputs.component }}" = "redis" ]; then
+            echo "dockerfile=Dockerfile" >> $GITHUB_OUTPUT
+            echo "image_name=redis" >> $GITHUB_OUTPUT
+            echo "build_arg_name=REDIS_VERSION" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event.inputs.component }}" = "sentinel" ]; then
+            echo "dockerfile=Dockerfile.sentinel" >> $GITHUB_OUTPUT
+            echo "image_name=redis-sentinel" >> $GITHUB_OUTPUT
+            echo "build_arg_name=REDIS_SENTINEL_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "dockerfile=Dockerfile.exporter" >> $GITHUB_OUTPUT
+            echo "image_name=redis-exporter" >> $GITHUB_OUTPUT
+            echo "build_arg_name=REDIS_EXPORTER_VERSION" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ${{ steps.config.outputs.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            ${{ steps.config.outputs.build_arg_name }}=${{ github.event.inputs.version }}
+          tags: quay.io/opstree/${{ steps.config.outputs.image_name }}:${{ github.event.inputs.version }} 


### PR DESCRIPTION
Introduces a GitHub Actions workflow to manually trigger Docker image releases for Redis, Sentinel, and Exporter components with configurable version selection