### PR TITLE
Sentinel - announce-ip <hostname> when resolve & announce are set

### DIFF
--- a/entrypoint-sentinel.sh
+++ b/entrypoint-sentinel.sh
@@ -25,6 +25,9 @@ sentinel_mode_setup(){
     echo "sentinel failover-timeout ${MASTER_GROUP_NAME} ${FAILOVER_TIMEOUT}"
     echo "SENTINEL resolve-hostnames ${RESOLVE_HOSTNAMES}"
     echo "SENTINEL announce-hostnames ${ANNOUNCE_HOSTNAMES}"
+    if [[ "${ANNOUNCE_HOSTNAMES}" == "yes" && "${RESOLVE_HOSTNAMES}" == "yes" ]]; then
+      echo "sentinel announce-ip ${IP}"
+    fi
     if [[ -n "${MASTER_PASSWORD}" ]];then
       echo "sentinel auth-pass ${MASTER_GROUP_NAME} ${MASTER_PASSWORD}"
     fi


### PR DESCRIPTION
As explained in this [comment](https://github.com/OT-CONTAINER-KIT/redis-operator/pull/1247#issuecomment-2690326603) and in the [official Redis documentation](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/#ip-addresses-and-dns-names), to avoid mixing IPs and hostnames, Sentinel must announce its hostname instead of its IP using the `announce-ip` configuration.