### PR TITLE
Update alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22 as builder
+FROM alpine:3.22 AS builder
 
 LABEL maintainer="Opstree Solutions"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19 as builder
+FROM alpine:3.22 as builder
 
 LABEL maintainer="Opstree Solutions"
 
@@ -31,7 +31,7 @@ RUN VERSION=$(echo ${REDIS_VERSION} | sed -e "s/^v//g"); \
     make -C redis-${VERSION} all; \
     make -C redis-${VERSION} install
 
-FROM alpine:3.19
+FROM alpine:3.22
 
 LABEL maintainer="Opstree Solutions"
 
@@ -42,6 +42,8 @@ ENV REDIS_PORT=6379
 LABEL version=1.0 \
       arch=$TARGETARCH \
       description="A production grade performance tuned redis docker image created by Opstree Solutions"
+
+RUN apk upgrade --no-cache
 
 COPY --from=builder /usr/local/bin/redis-server /usr/local/bin/redis-server
 COPY --from=builder /usr/local/bin/redis-cli /usr/local/bin/redis-cli

--- a/Dockerfile.exporter
+++ b/Dockerfile.exporter
@@ -1,4 +1,4 @@
-FROM alpine:3.22 as builder
+FROM alpine:3.22 AS builder
 
 ARG TARGETARCH
 

--- a/Dockerfile.exporter
+++ b/Dockerfile.exporter
@@ -1,4 +1,4 @@
-FROM alpine:3.19 as builder
+FROM alpine:3.22 as builder
 
 ARG TARGETARCH
 

--- a/Dockerfile.sentinel
+++ b/Dockerfile.sentinel
@@ -1,4 +1,4 @@
-FROM alpine:3.22 as builder
+FROM alpine:3.22 AS builder
 
 ARG TARGETARCH
 

--- a/Dockerfile.sentinel
+++ b/Dockerfile.sentinel
@@ -1,4 +1,4 @@
-FROM alpine:3.19 as builder
+FROM alpine:3.22 as builder
 
 ARG TARGETARCH
 
@@ -30,7 +30,7 @@ RUN VERSION=$(echo ${REDIS_SENTINEL_VERSION} | sed -e "s/^v//g"); \
     make -C redis-${VERSION} all; \
     make -C redis-${VERSION} install
 
-FROM alpine:3.19
+FROM alpine:3.22
 
 ARG TARGETARCH
 
@@ -40,6 +40,7 @@ LABEL version=1.0 \
       arch=$TARGETARCH \
       description="A production grade performance tuned redis docker image created by Opstree Solutions"
 
+RUN apk upgrade --no-cache
 
 COPY --from=builder /usr/local/bin/redis-cli /usr/local/bin/redis-cli
 COPY --from=builder /usr/local/bin/redis-sentinel /usr/local/bin/redis-sentinel


### PR DESCRIPTION
- Update Alpine image to 3.22 (The current image is going out of support soon)
- Add `apk upgrade --no-cache` for additional package upgrades on build
