### PR TITLE
Fix Redis cluster hostname announcement using FQDN

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,19 @@ redis_mode_setup() {
             echo cluster-config-file "${NODE_CONF_DIR}/nodes.conf"
         } >> /etc/redis/redis.conf
 
-        POD_HOSTNAME=$(hostname)
+        for i in {1..5}; do
+            POD_HOSTNAME=$(hostname -f 2>/dev/null)
+            if [[ -n "${POD_HOSTNAME}" ]]; then
+                break
+            fi
+            sleep 1
+        done
+
+        if [[ -z "${POD_HOSTNAME}" ]]; then
+            echo "Failed to resolve FQDN"
+            exit 1
+        fi
+
         POD_IP=$(hostname -i)
         sed -i -e "/myself/ s/[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/${POD_IP}/" "${NODE_CONF_DIR}/nodes.conf"
     else
@@ -142,7 +154,7 @@ start_redis() {
         else
             CLUSTER_ANNOUNCE_IP="${POD_IP}"
         fi
-        
+
         if [[ "${REDIS_MAJOR_VERSION}" != "v7" ]]; then
           exec redis-server /etc/redis/redis.conf \
           --cluster-announce-ip "${CLUSTER_ANNOUNCE_IP}"


### PR DESCRIPTION
Redis cluster nodes were announcing themselves with short hostnames (e.g., `my-redis-leader-0`) instead of FQDNs, preventing proper cluster communication.

Changed `POD_HOSTNAME=$(hostname)` to `POD_HOSTNAME=$(hostname -f)` in the Redis entrypoint script to use the fully qualified domain name (e.g., `my-redis-leader-0.my-redis-leader-headless.my-redis-namespace.svc.cluster.local`).

Redis cluster nodes can now discover and communicate with each other regardless of namespace