### PR TITLE
Dockerfile can also build redis modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,22 +14,27 @@ RUN apk add --no-cache su-exec tzdata make curl build-base linux-headers bash op
 
 WORKDIR /tmp
 
-RUN VERSION=$(echo ${REDIS_VERSION} | sed -e "s/^v//g"); \
-    case "${VERSION}" in \
-       latest | stable) REDIS_DOWNLOAD_URL="http://download.redis.io/redis-stable.tar.gz" && VERSION="stable";; \
-       *) REDIS_DOWNLOAD_URL="http://download.redis.io/releases/redis-${VERSION}.tar.gz";; \
-    esac; \
-    curl -fL -Lo redis-${VERSION}.tar.gz ${REDIS_DOWNLOAD_URL}; \
-    tar xvzf redis-${VERSION}.tar.gz; \
-    \
-    arch="$(uname -m)"; \
-    extraJemallocConfigureFlags="--with-lg-page=16"; \
-    if [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then \
-        sed -ri 's!cd jemalloc && ./configure !&'"$extraJemallocConfigureFlags"' !' /tmp/redis-${VERSION}/deps/Makefile; \
-    fi; \
-    export BUILD_TLS=yes; \
-    make -C redis-${VERSION} all; \
-    make -C redis-${VERSION} install
+SHELL   ["bash", "-xe", "-c"]
+
+RUN <<EOF
+VERSION=$(echo ${REDIS_VERSION} | sed -e "s/^v//g");
+case "${VERSION}" in
+   latest | stable) REDIS_DOWNLOAD_URL="http://download.redis.io/redis-stable.tar.gz" && VERSION="stable";;
+   *) REDIS_DOWNLOAD_URL="http://download.redis.io/releases/redis-${VERSION}.tar.gz";;
+esac;
+curl -fL -Lo redis-${VERSION}.tar.gz ${REDIS_DOWNLOAD_URL};
+tar xvzf redis-${VERSION}.tar.gz;
+
+arch="$(uname -m)";
+extraJemallocConfigureFlags="--with-lg-page=16";
+if [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then
+    sed -ri 's!cd jemalloc && ./configure !&'"$extraJemallocConfigureFlags"' !' /tmp/redis-${VERSION}/deps/Makefile;
+fi;
+export BUILD_TLS=yes;
+make -C redis-${VERSION} all;
+make -C redis-${VERSION} install;
+
+EOF
 
 FROM alpine:3.22
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22 AS builder
+FROM alpine:3.23 AS builder
 
 LABEL maintainer="Opstree Solutions"
 
@@ -25,6 +25,15 @@ WORKDIR /tmp
 SHELL   ["bash", "-xe", "-c"]
 
 RUN <<EOF
+# if llvm-config isn't found, it's probably at `/usr/bin/llvm-config-${llvm_version}`
+# see https://gitlab.alpinelinux.org/alpine/aports/-/work_items/17773 and remove once that hits the repositories
+if ! command -v llvm-config &> /dev/null; then
+    LLVM_CONFIG=$(find /usr/bin -name "llvm-config*" | head -n 1)
+    if [ -n "$LLVM_CONFIG" ]; then
+        export LLVM_CONFIG_PATH="$LLVM_CONFIG"
+    fi
+fi
+
 VERSION=$(echo ${REDIS_VERSION} | sed -e "s/^v//g");
 case "${VERSION}" in
    latest | stable) REDIS_DOWNLOAD_URL="http://download.redis.io/redis-stable.tar.gz" && VERSION="stable";;

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ FROM alpine:3.22
 LABEL maintainer="Opstree Solutions"
 
 ARG TARGETARCH
+ARG REDIS_VERSION="stable"
 
 ENV REDIS_PORT=6379
 
@@ -60,7 +61,7 @@ RUN apk upgrade --no-cache
 
 COPY --from=builder /usr/local/bin/redis-server /usr/local/bin/redis-server
 COPY --from=builder /usr/local/bin/redis-cli /usr/local/bin/redis-cli
-COPY --from=builder /tmp/redis-stable/modules/*/*.so /modules/
+COPY --from=builder /tmp/redis-*/modules/*/*.so /modules/
 
 RUN addgroup -S -g 1000 redis && adduser -S -G redis -u 1000 redis && \
     apk add --no-cache bash libstdc++ libssl3 libcrypto3

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL version=1.0 \
       description="A production grade performance tuned redis docker image created by Opstree Solutions"
 
 ARG REDIS_VERSION="stable"
-ARG BUILD_WITH_MODULES=yes
+ARG BUILD_WITH_MODULES=no
 ENV BUILD_WITH_MODULES=$BUILD_WITH_MODULES
 
 RUN apk add --no-cache su-exec tzdata make curl build-base linux-headers bash openssl-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,16 @@ LABEL version=1.0 \
       description="A production grade performance tuned redis docker image created by Opstree Solutions"
 
 ARG REDIS_VERSION="stable"
+ARG BUILD_WITH_MODULES=yes
+ENV BUILD_WITH_MODULES=$BUILD_WITH_MODULES
 
 RUN apk add --no-cache su-exec tzdata make curl build-base linux-headers bash openssl-dev
+RUN <<EOF
+if [ "$BUILD_WITH_MODULES" == "yes" ]; then
+ apk add autoconf automake bsd-compat-headers cmake cargo python3 py-virtualenv py3-pip git llvm-dev clang-dev clang-static ncurses-dev automake autoconf libtool
+ apk add clang clang-libclang g++ libffi-dev libgcc openssh openssl py3-cryptography py3-virtualenv python3-dev rsync tar unzip xsimd xz;
+fi
+EOF
 
 WORKDIR /tmp
 
@@ -52,6 +60,7 @@ RUN apk upgrade --no-cache
 
 COPY --from=builder /usr/local/bin/redis-server /usr/local/bin/redis-server
 COPY --from=builder /usr/local/bin/redis-cli /usr/local/bin/redis-cli
+COPY --from=builder /tmp/redis-stable/modules/*/*.so /modules/
 
 RUN addgroup -S -g 1000 redis && adduser -S -G redis -u 1000 redis && \
     apk add --no-cache bash libstdc++ libssl3 libcrypto3

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,12 @@ docker-build-redis:
 docker-push-redis:
 	docker buildx build --push --platform="linux/arm64,linux/amd64" -t ${IMG} -f Dockerfile .
 
+docker-build-redis-modules:
+	docker buildx build --build-arg BUILD_WITH_MODULES=yes --platform="linux/arm64,linux/amd64" -t "${IMG}-modules" -f Dockerfile .
+
+docker-push-redis-modules:
+	docker buildx build --build-arg BUILD_WITH_MODULES=yes --push --platform="linux/arm64,linux/amd64" -t "${IMG}-modules" -f Dockerfile .
+
 docker-build-redis-sentinel:
 	docker buildx build --platform="linux/arm64,linux/amd64" -t ${SENTINEL_IMG} -f Dockerfile.sentinel .
 


### PR DESCRIPTION
Redis includes several modules. The standard image does not include them.
This MR adds the capability for the Dockerfile to also build with modules. This allows for building images with or without the modules. 

relates to https://github.com/OT-CONTAINER-KIT/redis-operator/issues/1560