### PR TITLE
Enable using `hostname -f` for announcing hostnames in cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,30 @@ That's it
 
 > Note : latest tag would be comptabile with latest operator version.
 
+## Environment Variables
+
+The Redis container supports the following environment variables for configuration:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `POD_HOSTNAME_USE_FQDN` | `"true"` | Controls whether to use FQDN (`hostname -f`) or short hostname (`hostname -s`) for cluster announce hostname. Set to `"false"` to use short hostname. Useful in Kubernetes environments with specific hostname resolution requirements. |
+| `PERSISTENCE_ENABLED` | `"false"` | Enable Redis persistence (RDB snapshots and AOF). |
+| `DATA_DIR` | `"/data"` | Directory path for Redis data storage. |
+| `NODE_CONF_DIR` | `"/node-conf"` | Directory path for Redis cluster node configuration files. |
+| `EXTERNAL_CONFIG_FILE` | `"/etc/redis/external.conf.d/redis-additional.conf"` | Path to external Redis configuration file for additional custom settings. |
+| `REDIS_MAJOR_VERSION` | `"v7"` | Redis major version to use. |
+
+Additional environment variables for cluster setup:
+
+| Variable | Description |
+|----------|-------------|
+| `SETUP_MODE` | Setup mode: `cluster` or `standalone` |
+| `SERVER_MODE` | Server mode: `master` or `slave` |
+| `REDIS_PASSWORD` | Redis authentication password |
+| `MASTER_IP` | Master node IP address (for slave nodes) |
+| `SLAVE_IP` | Slave node IP address |
+| `MASTER_LIST` | Space-separated list of master nodes (format: `ip:port ip:port ...`) |
+
 ## Building Image
 
 #### Redis Docker Image

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,7 @@ DATA_DIR=${DATA_DIR:-"/data"}
 NODE_CONF_DIR=${NODE_CONF_DIR:-"/node-conf"}
 EXTERNAL_CONFIG_FILE=${EXTERNAL_CONFIG_FILE:-"/etc/redis/external.conf.d/redis-additional.conf"}
 REDIS_MAJOR_VERSION=${REDIS_MAJOR_VERSION:-"v7"}
+POD_HOSTNAME_USE_FQDN=${POD_HOSTNAME_USE_FQDN:-"true"}
 
 apply_permissions() {
     chgrp -R 1000 /etc/redis
@@ -41,7 +42,11 @@ redis_mode_setup() {
             echo cluster-config-file "${NODE_CONF_DIR}/nodes.conf"
         } >> /etc/redis/redis.conf
 
-        POD_HOSTNAME=$(hostname)
+        if [[ "${POD_HOSTNAME_USE_FQDN}" == "true" ]]; then
+            POD_HOSTNAME=$(hostname -f)
+        else
+            POD_HOSTNAME=$(hostname)
+        fi
         POD_IP=$(hostname -i)
         sed -i -e "/myself/ s/[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/${POD_IP}/" "${NODE_CONF_DIR}/nodes.conf"
     else


### PR DESCRIPTION
# Changes

- Adds a special environment variable to use `hostname -f` for determining POD_HOSTNAME instead of `hostname`, so that nodes register themselves to a Redis cluster with their full FQDN, so that clients can talk to each of the nodes within Kubernetes.


Also took the liberty to table up all the environment variables used in the `entrypoint.sh` file to the README